### PR TITLE
Add separate simplified toggles for description and solution. #74

### DIFF
--- a/src/pages/popup/VulnerabilityPanel.tsx
+++ b/src/pages/popup/VulnerabilityPanel.tsx
@@ -79,7 +79,8 @@ const UrlListModal: React.FC<{ instances: AlertInstance[], onClose: () => void }
 export const VulnerabilityPanel: React.FC<VulnerabilityPanelProps> = ({ alerts }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isUrlsVisible, setUrlsVisible] = useState(false);
-  const [isSimplified, setSimplified] = useState(false);
+  const [showSimplifiedDesc, setShowSimplifiedDesc] = useState(false);
+  const [showSimplifiedSol, setShowSimplifiedSol] = useState(false);
   const [templates, setTemplates] = useState<VulnerabilityTemplate[]>([]);
   const alert = alerts[currentIndex];
   const primaryInstance = alert.instances[0];
@@ -161,22 +162,28 @@ export const VulnerabilityPanel: React.FC<VulnerabilityPanelProps> = ({ alerts }
             {/* Render toggle only if a simplified version exists */}
             {template?.simplified_description && (
               <div className="flex items-center text-xs border border-gray-600 rounded-md p-0.5">
-                <button onClick={() => setSimplified(false)} className={`px-2 py-0.5 rounded-sm ${!isSimplified ? 'bg-blue-600' : 'hover:bg-gray-700'}`}>Standard</button>
-                <button onClick={() => setSimplified(true)} className={`px-2 py-0.5 rounded-sm ${isSimplified ? 'bg-blue-600' : 'hover:bg-gray-700'}`}>Simplified</button>
+                <button onClick={() => setShowSimplifiedDesc(false)} className={`px-2 py-0.5 rounded-sm ${!showSimplifiedDesc ? 'bg-blue-600' : 'hover:bg-gray-700'}`}>Standard</button>
+                <button onClick={() => setShowSimplifiedDesc(true)} className={`px-2 py-0.5 rounded-sm ${showSimplifiedDesc ? 'bg-blue-600' : 'hover:bg-gray-700'}`}>Simplified</button>
               </div>
             )}
           </div>
           <p className="whitespace-pre-wrap">
-            {isSimplified ? template?.simplified_description : alert.description}
+            {showSimplifiedDesc ? template?.simplified_description : alert.description}
           </p>
         </div>
 
         <div className="mb-3">
           <div className="flex items-center justify-between mb-1">
             <h4 className="text-md font-bold text-blue-400">Solution</h4>
+            {template?.simplified_solution && (
+              <div className="flex items-center text-xs border border-gray-600 rounded-md p-0.5">
+                <button onClick={() => setShowSimplifiedSol(false)} className={`px-2 py-0.5 rounded-sm ${!showSimplifiedSol ? 'bg-blue-600' : 'hover:bg-gray-700'}`}>Standard</button>
+                <button onClick={() => setShowSimplifiedSol(true)} className={`px-2 py-0.5 rounded-sm ${showSimplifiedSol ? 'bg-blue-600' : 'hover:bg-gray-700'}`}>Simplified</button>
+              </div>
+            )}
           </div>
           <p className="whitespace-pre-wrap">
-            {isSimplified ? template?.simplified_solution : alert.solution}
+            {showSimplifiedSol ? template?.simplified_solution : alert.solution}
           </p>
         </div>
 


### PR DESCRIPTION
Introduces independent toggles for displaying simplified versions of the vulnerability description and solution. This allows users to switch between standard and simplified views for each section individually, improving clarity and usability.